### PR TITLE
Fix: Update 404 page documentation link to new domain

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -69,7 +69,7 @@
                         <div class="flex flex-wrap gap-3 mt-3 justify-center md:justify-start">
                             <a href="/blog" class="text-everest-light hover:text-everest-blue transition-colors">Blog</a>
                             <span class="text-gray-300">•</span>
-                            <a href="https://docs.percona.com/everest/" target="_blank" class="text-everest-light hover:text-everest-blue transition-colors">Documentation</a>
+                            <a href="https://openeverest.io/docs/" target="_blank" class="text-everest-light hover:text-everest-blue transition-colors">Documentation</a>
                             <span class="text-gray-300">•</span>
                             <a href="/support" class="text-everest-light hover:text-everest-blue transition-colors">Support</a>
                         </div>


### PR DESCRIPTION
### Summary
The 404 page (`static/404.html`) contained a hardcoded link pointing to the old documentation site (`docs.percona.com`).

### Changes
- Updated the "Documentation" link on the 404 page to point to the correct URL: `https://openeverest.io/docs/`.
- Validated that the style and target attributes remain unchanged.

Fixes #23