### PR TITLE
feat: make navbar sticky on scroll

### DIFF
--- a/hugo_stats.json
+++ b/hugo_stats.json
@@ -441,6 +441,7 @@
       "to-gray-50",
       "to-purple-50",
       "to-white",
+      "top-0",
       "top-4",
       "top-8",
       "tracking-wide",

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 
-<header class="bg-white border-b border-gray-200 shadow-sm">
+<header class="bg-white border-b border-gray-200 shadow-sm sticky top-0 z-50">
     <nav class="container mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div class="flex justify-between items-center">
             <a href="/" class="flex items-center">


### PR DESCRIPTION
## What is this about ?
Makes the navigation bar sticky so it stays visible as users scroll down the page for a better user experience. Also, Improves navigation UX users don't have to scroll back to the top to access nav links.

## How
Added `sticky top-0 z-50` Tailwind CSS classes in the header file.

## Tested
Verified locally on macOS Apple Silicon using Docker.