### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -29,17 +29,17 @@ jobs:
       TZ: UTC
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Install Hugo
         run: |
           curl -sLJO "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
@@ -72,7 +72,7 @@ jobs:
             --minify \
             --baseURL "https://openeverest.io/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./public
   deploy:
@@ -84,4 +84,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Why

Actions must now be pinned to full-length commit SHAs at the org level. A mutable tag means the action's owner — or anyone who compromises them — can change what executes in our pipelines retroactively, and unpinned workflows no longer run.

## What

Every `uses:` tag reference is replaced with the commit SHA that tag points at today, keeping the human-readable version in a trailing comment:

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
```

- **Behaviour-preserving** — same code runs, it just can't change underneath us.
- Annotated tags were dereferenced to the underlying commit.
- Comments use the most specific release tag pointing at that commit (`v4.4.0` rather than `v4`), matching the convention already used in `openeverest/main`.
- Line-for-line; no reordering or reformatting.

Generated mechanically and YAML-validated. Part of an org-wide sweep across all repositories.
